### PR TITLE
[RD-48428] Use a patched filebeat package

### DIFF
--- a/Formula/filebeat@6.8.rb
+++ b/Formula/filebeat@6.8.rb
@@ -2,9 +2,9 @@ class FilebeatAT68 < Formula
   desc "File harvester to ship log files to Elasticsearch or Logstash"
   homepage "https://www.elastic.co/products/beats/filebeat"
   # Hacked filebeat repo to remove x-pack (not open source licensed) and fix some build issues
-  url "https://mac-repo.scivisum.co.uk/sources/filebeat/filebeat-noxpack-6.8.23.tar.zst"
-  sha256 "a7adf48d66cb9d3d3cfec066dd9a648f3526ce6920a228c17addce1e326b5e31"
-  revision 1
+  url "https://mac-repo.scivisum.co.uk/sources/filebeat/filebeat-noxpack-6.8.23-patched.tar.zst"
+  sha256 "b7403874f30b1db009b5c5f8c840a6d388503a55f10e829307c2139d3548a72a"
+  revision 2
 
   depends_on "go" => :build
   depends_on "python@3.10" => :build


### PR DESCRIPTION
- The python requirements.txt in the new package has been modified to bring a compatible version of PyYAML (5.4.1 -> 5.3.1).